### PR TITLE
replaced &Vec<u8> with &[u8] in function signatures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,16 @@
 pub mod ec_vrf {
-    extern crate rand_os;
-    extern crate curve25519_dalek;
-    extern crate sha3;
+    use curve25519_dalek::scalar::Scalar;
     use rand_os::OsRng;
     use sha3::{Digest, Sha3_256 as SHA3};
-    use curve25519_dalek::scalar::{Scalar};
     pub mod curve25519 {
         use super::*;
-        use curve25519_dalek::edwards::{EdwardsPoint};
         use curve25519_dalek::constants::ED25519_BASEPOINT_POINT as g;
+        use curve25519_dalek::edwards::EdwardsPoint;
         type EcPoint = EdwardsPoint;
         pub struct VrfProof {
             gamma: EcPoint,
             c: [u8; 32],
-            s: Scalar
+            s: Scalar,
         }
         fn sha3(b: Vec<u8>) -> [u8; 32] {
             let mut hasher = SHA3::default();
@@ -28,41 +25,39 @@ pub mod ec_vrf {
         fn hash_to_point(b: Vec<u8>) -> EcPoint {
             let hash = sha3(b);
             let s = Scalar::from_bytes_mod_order(hash);
-            return g*s
+            g * s
         }
         fn serialize_point(p: EcPoint) -> [u8; 32] {
-            return p.to_montgomery().to_bytes();
+            p.to_montgomery().to_bytes()
         }
-        pub fn prove(input: &Vec<u8>, privkey: Scalar) -> 
-            ([u8; 32], VrfProof) {
-                let h = hash_to_point(input.to_vec());
-                let gamma = h*privkey;
-                let mut csprng: OsRng = OsRng::new().unwrap();
-                let k: Scalar = Scalar::random(&mut csprng);
-                let mut hasher = SHA3::default();
-                hasher.input(serialize_point(g));
-                hasher.input(serialize_point(h));
-                hasher.input(serialize_point(g*privkey));
-                hasher.input(serialize_point(h*privkey));
-                hasher.input(serialize_point(g*k));
-                hasher.input(serialize_point(h*k));
-                let mut c = [0 as u8; 32];
-                let hres = hasher.result();
-                for i in 0..hres.len() {
-                    c[i] = hres[i];
-                }
-                let c_scalar = Scalar::from_bytes_mod_order(c);
-                let s = k - c_scalar*privkey;
-                let beta = sha3(serialize_point(gamma).to_vec());
-                (beta, VrfProof {gamma: gamma, c: c, s: s})
-            }
-
-        pub fn verify(input: &Vec<u8>, pubkey: EcPoint, output: [u8; 32], 
-                      proof: VrfProof) -> bool {
-            let c_scalar = Scalar::from_bytes_mod_order(proof.c);
-            let u = pubkey*c_scalar + g*proof.s;
+        pub fn prove(input: &[u8], privkey: Scalar) -> ([u8; 32], VrfProof) {
             let h = hash_to_point(input.to_vec());
-            let v = proof.gamma*c_scalar + h*proof.s;
+            let gamma = h * privkey;
+            let mut csprng: OsRng = OsRng::new().unwrap();
+            let k: Scalar = Scalar::random(&mut csprng);
+            let mut hasher = SHA3::default();
+            hasher.input(serialize_point(g));
+            hasher.input(serialize_point(h));
+            hasher.input(serialize_point(g * privkey));
+            hasher.input(serialize_point(h * privkey));
+            hasher.input(serialize_point(g * k));
+            hasher.input(serialize_point(h * k));
+            let mut c = [0 as u8; 32];
+            let hres = hasher.result();
+            for i in 0..hres.len() {
+                c[i] = hres[i];
+            }
+            let c_scalar = Scalar::from_bytes_mod_order(c);
+            let s = k - c_scalar * privkey;
+            let beta = sha3(serialize_point(gamma).to_vec());
+            (beta, VrfProof { gamma, c, s })
+        }
+
+        pub fn verify(input: &[u8], pubkey: EcPoint, output: [u8; 32], proof: VrfProof) -> bool {
+            let c_scalar = Scalar::from_bytes_mod_order(proof.c);
+            let u = pubkey * c_scalar + g * proof.s;
+            let h = hash_to_point(input.to_vec());
+            let v = proof.gamma * c_scalar + h * proof.s;
 
             let mut hasher = SHA3::default();
             hasher.input(serialize_point(g));
@@ -76,19 +71,18 @@ pub mod ec_vrf {
             for i in 0..hres.len() {
                 local_c[i] = hres[i];
             }
-            sha3(serialize_point(proof.gamma).to_vec()) == output &&
-                local_c == proof.c
+            sha3(serialize_point(proof.gamma).to_vec()) == output && local_c == proof.c
         }
     }
     pub mod ristretto {
         use super::*;
-        use curve25519_dalek::ristretto::{RistrettoPoint};
         use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT as g;
+        use curve25519_dalek::ristretto::RistrettoPoint;
         type EcPoint = RistrettoPoint;
         pub struct VrfProof {
             gamma: EcPoint,
             c: [u8; 32],
-            s: Scalar
+            s: Scalar,
         }
         fn sha3(b: Vec<u8>) -> [u8; 32] {
             let mut hasher = SHA3::default();
@@ -103,41 +97,39 @@ pub mod ec_vrf {
         fn hash_to_point(b: Vec<u8>) -> EcPoint {
             let hash = sha3(b);
             let s = Scalar::from_bytes_mod_order(hash);
-            return g*s
+            g * s
         }
         fn serialize_point(p: EcPoint) -> [u8; 32] {
-            return p.compress().to_bytes();
+            p.compress().to_bytes()
         }
-        pub fn prove(input: &Vec<u8>, privkey: Scalar) -> 
-            ([u8; 32], VrfProof) {
-                let h = hash_to_point(input.to_vec());
-                let gamma = h*privkey;
-                let mut csprng: OsRng = OsRng::new().unwrap();
-                let k: Scalar = Scalar::random(&mut csprng);
-                let mut hasher = SHA3::default();
-                hasher.input(serialize_point(g));
-                hasher.input(serialize_point(h));
-                hasher.input(serialize_point(g*privkey));
-                hasher.input(serialize_point(h*privkey));
-                hasher.input(serialize_point(g*k));
-                hasher.input(serialize_point(h*k));
-                let mut c = [0 as u8; 32];
-                let hres = hasher.result();
-                for i in 0..hres.len() {
-                    c[i] = hres[i];
-                }
-                let c_scalar = Scalar::from_bytes_mod_order(c);
-                let s = k - c_scalar*privkey;
-                let beta = sha3(serialize_point(gamma).to_vec());
-                (beta, VrfProof {gamma: gamma, c: c, s: s})
-            }
-
-        pub fn verify(input: &Vec<u8>, pubkey: EcPoint, output: [u8; 32], 
-                      proof: VrfProof) -> bool {
-            let c_scalar = Scalar::from_bytes_mod_order(proof.c);
-            let u = pubkey*c_scalar + g*proof.s;
+        pub fn prove(input: &[u8], privkey: Scalar) -> ([u8; 32], VrfProof) {
             let h = hash_to_point(input.to_vec());
-            let v = proof.gamma*c_scalar + h*proof.s;
+            let gamma = h * privkey;
+            let mut csprng: OsRng = OsRng::new().unwrap();
+            let k: Scalar = Scalar::random(&mut csprng);
+            let mut hasher = SHA3::default();
+            hasher.input(serialize_point(g));
+            hasher.input(serialize_point(h));
+            hasher.input(serialize_point(g * privkey));
+            hasher.input(serialize_point(h * privkey));
+            hasher.input(serialize_point(g * k));
+            hasher.input(serialize_point(h * k));
+            let mut c = [0 as u8; 32];
+            let hres = hasher.result();
+            for i in 0..hres.len() {
+                c[i] = hres[i];
+            }
+            let c_scalar = Scalar::from_bytes_mod_order(c);
+            let s = k - c_scalar * privkey;
+            let beta = sha3(serialize_point(gamma).to_vec());
+            (beta, VrfProof { gamma, c, s })
+        }
+
+        pub fn verify(input: &[u8], pubkey: EcPoint, output: [u8; 32], proof: VrfProof) -> bool {
+            let c_scalar = Scalar::from_bytes_mod_order(proof.c);
+            let u = pubkey * c_scalar + g * proof.s;
+            let h = hash_to_point(input.to_vec());
+            let v = proof.gamma * c_scalar + h * proof.s;
 
             let mut hasher = SHA3::default();
             hasher.input(serialize_point(g));
@@ -151,27 +143,25 @@ pub mod ec_vrf {
             for i in 0..hres.len() {
                 local_c[i] = hres[i];
             }
-            sha3(serialize_point(proof.gamma).to_vec()) == output &&
-                local_c == proof.c
+            sha3(serialize_point(proof.gamma).to_vec()) == output && local_c == proof.c
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    extern crate rand_os;
-    use curve25519_dalek::scalar::{Scalar};
+    use super::*;
     use curve25519_dalek::constants::ED25519_BASEPOINT_POINT as g;
     use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT as rg;
+    use curve25519_dalek::scalar::Scalar;
     use rand_os::OsRng;
-    use super::*;
 
     #[test]
     fn curve25519() {
         let mut csprng: OsRng = OsRng::new().unwrap();
         let privkey: Scalar = Scalar::random(&mut csprng);
-        let pubkey = g*privkey;
-        let input = vec![1,2,3,4,5,6,7,8];
+        let pubkey = g * privkey;
+        let input = vec![1, 2, 3, 4, 5, 6, 7, 8];
         let (output, proof) = ec_vrf::curve25519::prove(&input, privkey);
         assert!(ec_vrf::curve25519::verify(&input, pubkey, output, proof));
     }
@@ -180,8 +170,8 @@ mod tests {
     fn ristretto() {
         let mut csprng: OsRng = OsRng::new().unwrap();
         let privkey: Scalar = Scalar::random(&mut csprng);
-        let pubkey = rg*privkey;
-        let input = vec![1,2,3,4,5,6,7,8];
+        let pubkey = rg * privkey;
+        let input = vec![1, 2, 3, 4, 5, 6, 7, 8];
         let (output, proof) = ec_vrf::ristretto::prove(&input, privkey);
         assert!(ec_vrf::ristretto::verify(&input, pubkey, output, proof));
     }


### PR DESCRIPTION
Rust can automatically coerce `&Vec<T>` into `&[T]`, so this is more general.

also fixed some clippy warnings and formatting issues